### PR TITLE
VER-4980: HttpClientV2 migration + Bootstrap v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ More evidence sources will be added in due course.
 
 ## Routes
 
-| Method | Path                                             | Description                                           |
-|--------|--------------------------------------------------|-------------------------------------------------------|
-|  POST  | ```/questions```                                 | Get questions and a correlation id for a set of identifiers  |
-|  POST  | ```/answers```                                   | Supply answers for set of previously fetched questions          |
+| Method | Path             | Description                                                 |
+|--------|------------------|-------------------------------------------------------------|
+| POST   | ```/questions``` | Get questions and a correlation id for a set of identifiers |
+| POST   | ```/answers```   | Supply answers for set of previously fetched questions      |
 
 ### POST /questions
 Include a POST JSON body containing a set of identifiers for the questions such as:
@@ -54,10 +54,10 @@ In order to use this service, you must be **authorised** by the Verification tea
 
 #### Response
 
-| Status | Description                                                                                                                                             |
-|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 200    | Returns a correlation id, along with a (possibly empty) set of questions for the identifiers given|
-| 403    | You are not authorized to use the question repository - see above |
+| Status | Description                                                                                        |
+|--------|----------------------------------------------------------------------------------------------------|
+| 200    | Returns a correlation id, along with a (possibly empty) set of questions for the identifiers given |
+| 403    | You are not authorized to use the question repository - see above                                  |
 |
 
 Example response, showing 2 possible questions that can be asked (both from P60 evidence source):
@@ -192,11 +192,11 @@ TODO add more examples for different evidence sources.
 
 #### Response
 
-| Status | Description                                           |
-|--------|-------------------------------------------------------|
-| 200    | The outcome of the answer check, indicating a correct or incorrect response|
-| 403    | You are not authorized to use the question repository - see above |
-| 404    | The supplied correlation id and selection did not match any known questions|
+| Status | Description                                                                 |
+|--------|-----------------------------------------------------------------------------|
+| 200    | The outcome of the answer check, indicating a correct or incorrect response |
+| 403    | You are not authorized to use the question repository - see above           |
+| 404    | The supplied correlation id and selection did not match any known questions |
 
 The outcome of each question answered will be provided in the response, for example:
 
@@ -225,7 +225,9 @@ It is up to the calling service to decide which answers they would like to know 
 
 ## How to run the tests
 
-```sbt clean test``` and  ```sbt clean it/test```
+```sbt clean test```
+
+For IT tests currently you must start up the services ```sm2 --start IV_ALL``` and then ```sbt clean it/test```
 
 Note: acceptance testing is done as part of the main IV suite with question repository enabled from IV backend, see https://github.com/hmrc/identity-verification-ui-tests
 

--- a/app/uk/gov/hmrc/identityverificationquestions/models/payment/Payment.scala
+++ b/app/uk/gov/hmrc/identityverificationquestions/models/payment/Payment.scala
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.identityverificationquestions.models.payment
 
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
-import java.time.LocalDate
 import play.api.libs.json.{Reads, __}
-import uk.gov.hmrc.http.controllers.JsPathEnrichment._
+
+import java.time.LocalDate
 
 case class Payment(paymentDate: LocalDate,
                    taxablePayYTD: Option[BigDecimal] = None,
@@ -44,10 +44,10 @@ object Payment {
     }
 
     ((__ \ "pmtDate").read[LocalDate] and
-      (__ \ "mandatoryMonetaryAmount").tolerantReadNullable[Seq[PaymentItem]] and
-      (__ \ "niLettersAndValues").tolerantReadNullable[Seq[NiLettersAndValues]] and
-      (__ \ "optionalMonetaryAmount").tolerantReadNullable[Seq[PaymentItem]] and
-      (__ \ "leavingDate").tolerantReadNullable[LocalDate]
+      (__ \ "mandatoryMonetaryAmount").readNullable[Seq[PaymentItem]] and
+      (__ \ "niLettersAndValues").readNullable[Seq[NiLettersAndValues]] and
+      (__ \ "optionalMonetaryAmount").readNullable[Seq[PaymentItem]] and
+      (__ \ "leavingDate").readNullable[LocalDate]
       ) { (paymentDate, optMandatoryPaymentItems, optNiLettersAndValues, optionalMonetaryPaymentItems, leavingDate) =>
       val niLettersAndValues = optNiLettersAndValues.getOrElse(Seq.empty)
       val mandatoryPayments = optMandatoryPaymentItems.getOrElse(Seq.empty)

--- a/app/uk/gov/hmrc/identityverificationquestions/models/taxcredit/NtcJsonFormats.scala
+++ b/app/uk/gov/hmrc/identityverificationquestions/models/taxcredit/NtcJsonFormats.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.identityverificationquestions.models.taxcredit
 
-import java.time.LocalDate
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import uk.gov.hmrc.http.controllers.JsPathEnrichment._
+
+import java.time.LocalDate
 
 
 trait NtcJsonFormats {
@@ -53,8 +53,8 @@ trait NtcJsonFormats {
   }
   
   implicit val taxCreditClaimReads: Reads[TaxCreditClaim] = (
-    (__ \ "applicant1" \ "bankOrBuildingSociety").tolerantReadNullable[TaxCreditBankAccount] and
-    (__ \ "applicant2" \ "bankOrBuildingSociety").tolerantReadNullable[TaxCreditBankAccount] and
+    (__ \ "applicant1" \ "bankOrBuildingSociety").readNullable[TaxCreditBankAccount] and
+    (__ \ "applicant2" \ "bankOrBuildingSociety").readNullable[TaxCreditBankAccount] and
     (__ \ "previousPayment").readNullable[Seq[Option[TaxCreditPayment]]]
   )((account1, account2, payments) => {
     val accounts = account1.toSeq ++ account2.toSeq

--- a/app/uk/gov/hmrc/identityverificationquestions/monitoring/analytics/AnalyticsModel.scala
+++ b/app/uk/gov/hmrc/identityverificationquestions/monitoring/analytics/AnalyticsModel.scala
@@ -16,8 +16,22 @@
 
 package uk.gov.hmrc.identityverificationquestions.monitoring.analytics
 
+import play.api.libs.json.{Json, OFormat}
+
 case class DimensionValue(index: Int, value: String)
 
 case class Event(category: String, action: String, label: String, dimensions: Seq[DimensionValue])
 
 case class AnalyticsRequest(gaClientId: Option[String], events: Seq[Event])
+
+object DimensionValue {
+  implicit val format: OFormat[DimensionValue] = Json.format[DimensionValue]
+}
+
+object Event {
+  implicit val format: OFormat[Event] = Json.format[Event]
+}
+
+object AnalyticsRequest {
+  implicit val format: OFormat[AnalyticsRequest] = Json.format[AnalyticsRequest]
+}

--- a/app/uk/gov/hmrc/identityverificationquestions/sources/P45/P45Connector.scala
+++ b/app/uk/gov/hmrc/identityverificationquestions/sources/P45/P45Connector.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.identityverificationquestions.sources.P45
 import play.api.Logging
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{CoreGet, HeaderCarrier, NotFoundException, UpstreamErrorResponse}
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException, StringContextOps, UpstreamErrorResponse}
 import uk.gov.hmrc.identityverificationquestions.config.AppConfig
 import uk.gov.hmrc.identityverificationquestions.connectors.QuestionConnector
 import uk.gov.hmrc.identityverificationquestions.connectors.utilities.HodConnectorConfig
@@ -32,7 +33,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class P45Connector @Inject()(val http: CoreGet, metricsService: MetricsService, val appConfig: AppConfig) extends QuestionConnector[Payment]
+class P45Connector @Inject()(val http: HttpClientV2, metricsService: MetricsService, val appConfig: AppConfig) extends QuestionConnector[Payment]
   with HodConnectorConfig
   with TaxYearBuilder
   with Logging {
@@ -50,7 +51,7 @@ class P45Connector @Inject()(val http: CoreGet, metricsService: MetricsService, 
       val headers = desHeaders.headers(List("Authorization", "X-Request-Id")) ++ desHeaders.extraHeaders
 
       metricsService.timeToGetResponseWithMetrics[Seq[Employment]](metricsService.p45ConnectorTimer.time()) {
-        http.GET[Seq[Employment]](url, headers = headers)(implicitly, hc, ec).recoverWith {
+        http.get(url"$url").setHeader(headers:_*).execute[Seq[Employment]].recoverWith {
           case e: UpstreamErrorResponse if e.statusCode == 404 =>
             logger.info(s"$serviceName is not available for user: ${selection.toList.map(selection.obscureIdentifier).mkString(",")}")
             Future.successful(Seq())

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val scoverageSettings = {
   import scoverage.*
   Seq(
     ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;.*BuildInfo.*;.*TestVerifyPersonalIdentityController.*;.*views.*;.*Routes.*;.*RoutesPrefix.*;",
-    ScoverageKeys.coverageMinimumStmtTotal := 85,
+    ScoverageKeys.coverageMinimumStmtTotal := 87,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )}
@@ -29,9 +29,6 @@ lazy val microservice = Project(appName, file("."))
   .settings(routesImport ++= Seq("models._"))
   .settings(playDefaultPort := 10101)
   .settings(scoverageSettings *)
-  .settings(resolvers ++= Seq(
-    Resolver.jcenterRepo
-  ))
 
 
 lazy val it = project

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -20,7 +20,7 @@ include "backend.conf"
 appName = identity-verification-questions
 
 # Default http client
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"

--- a/it/test/connectors/empRef/EmpRefConnectorISpec.scala
+++ b/it/test/connectors/empRef/EmpRefConnectorISpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.empRef
+
+import ch.qos.logback.classic.Level
+import iUtils.{BaseISpec, LogCapturing, WireMockStubs}
+import play.api.libs.json.Json
+import uk.gov.hmrc.domain.{EmpRef, Nino}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.identityverificationquestions.models.{PayePayment, PayePaymentAmount, PayePaymentsDetails, Selection}
+import uk.gov.hmrc.identityverificationquestions.sources.empRef.EmpRefConnector
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+
+class EmpRefConnectorISpec extends BaseISpec with LogCapturing with WireMockStubs {
+
+  def await[A](future: Future[A]): A = Await.result(future, 50.second)
+
+  "EmpRefConnector" should {
+    lazy val connector: EmpRefConnector = app.injector.instanceOf[EmpRefConnector]
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val validPaymentDetails = PayePaymentsDetails(Some(List(PayePayment(PayePaymentAmount(BigDecimal("1234"), "GBP"), "2025-03-03"))))
+    val responseBody = Json.toJson(validPaymentDetails).toString()
+    val payeRef: EmpRef = EmpRef("fakeTaxOfficeNumber", "fakeTaxOfficeReference")
+    val selectionPayeRef: Selection = Selection(payeRef)
+    val url = "/pay-as-you-earn/employers/fakeTaxOfficeNumber/fakeTaxOfficeReference/account/payments"
+
+    "successfully execute a valid request" in {
+      stubGetWithResponseBody(url, OK, responseBody)
+      val result: Seq[PayePaymentsDetails] = await(connector.getRecords(selectionPayeRef))
+
+      result.toList.head shouldBe validPaymentDetails
+    }
+
+    "return empty Seq() AND warnLogs if no NINO is given" in {
+      withCaptureOfLoggingFrom[EmpRefConnector] { logs =>
+        stubGetWithResponseBody(url, OK, responseBody)
+        val ninoIdentifier: Nino = Nino("AA000003B")
+        val selectionNino: Selection = Selection(ninoIdentifier)
+        val result: Seq[PayePaymentsDetails] = await(connector.getRecords(selectionNino))
+
+        result shouldBe Seq.empty
+
+        val warnLogs = logs.filter(_.getLevel == Level.WARN)
+        warnLogs.size shouldBe 1
+        warnLogs.head.getMessage should include (s"desPayeService, No payeRef for selection: $selectionNino")
+      }
+    }
+
+    "return PayePaymentsDetails(None) for an empty request" in {
+      val emptyPaymentDetails = PayePaymentsDetails(None)
+
+      stubGetWithResponseBody(url, OK, Json.toJson(emptyPaymentDetails).toString())
+      val result: Seq[PayePaymentsDetails] = await(connector.getRecords(selectionPayeRef))
+
+      result.toList.head shouldBe emptyPaymentDetails
+    }
+
+    "return an empty Seq() if Get request throws UpstreamErrorResponse for NOT_FOUND status" in {
+      withCaptureOfLoggingFrom[EmpRefConnector] { logs =>
+        stubGetWithResponseBody(url, NOT_FOUND, responseBody)
+        val result: Seq[PayePaymentsDetails] = await(connector.getRecords(selectionPayeRef))
+        result shouldBe Seq.empty
+
+        val infoLogs = logs.filter(_.getLevel == Level.INFO)
+        infoLogs.size shouldBe 1
+        infoLogs.head.getMessage should include ("desPayeService is not available for user")
+      }
+    }
+  }
+
+}

--- a/it/test/connectors/p45/P45ConnectorISpec.scala
+++ b/it/test/connectors/p45/P45ConnectorISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package test.connectors.p45
+package connectors.p45
 
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
-import test.iUtils.BaseISpec
-import uk.gov.hmrc.domain.Nino
+import ch.qos.logback.classic.Level
+import iUtils.{BaseISpec, LogCapturing, TestTaxYearBuilder, WireMockStubs}
+import play.api.libs.json.Json
+import uk.gov.hmrc.domain.{EmpRef, Nino}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.identityverificationquestions.models.Selection
 import uk.gov.hmrc.identityverificationquestions.models.payment.Payment
@@ -29,45 +29,113 @@ import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 
-class P45ConnectorISpec extends BaseISpec {
+class P45ConnectorISpec extends BaseISpec with LogCapturing with WireMockStubs with TestTaxYearBuilder {
 
   def await[A](future: Future[A]): A = Await.result(future, 50.second)
-  override lazy val fakeApplication: Application = new GuiceApplicationBuilder().build()
+
+  private val jsonParse: String =
+    """
+      |{
+      |  "individual": {
+      |    "employments": {
+      |      "employment": [
+      |        {
+      |          "payments": {
+      |            "inYear": [
+      |              {
+      |                "payId": "20425",
+      |                "leavingDate": "2012-06-22",
+      |                "payFreq": "IO",
+      |                "mandatoryMonetaryAmount": [
+      |                  {
+      |                    "type": "TaxablePayYTD",
+      |                    "amount": 0
+      |                  },
+      |                  {
+      |                    "type": "TaxablePay",
+      |                    "amount": 102.02
+      |                  },
+      |                  {
+      |                    "type": "TotalTaxYTD",
+      |                    "amount": 130.99
+      |                  },
+      |                  {
+      |                    "type": "TaxDeductedOrRefunded",
+      |                    "amount": 155.02
+      |                  }
+      |                ],
+      |                "niLettersAndValues": [
+      |                  {
+      |                    "niFigure": [
+      |                      {
+      |                        "type": "EmpeeContribnsInPd",
+      |                        "amount": 100.02
+      |                      },
+      |                      {
+      |                        "type": "EmpeeContribnsYTD",
+      |                        "amount": 130.99
+      |                      }
+      |                    ]
+      |                  }
+      |                ],
+      |                "starter": {
+      |                  "startDate": "2011-08-13"
+      |                },
+      |                "pmtDate": "2015-04-06",
+      |                "rcvdDate": "2015-04-06",
+      |                "taxYear": "14-15"
+      |              }
+      |            ]
+      |          }
+      |        }
+      |      ]
+      |    }
+      |  }
+      |}
+      |""".stripMargin
+  private val responseBody: String = Json.parse(jsonParse).toString()
 
   "get p45 returns" should {
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    val paymentDate: LocalDate = LocalDate.now().minusMonths(6).minusDays(5)
+    val connector: P45Connector = app.injector.instanceOf[P45Connector]
+    val ninoIdentifier: Nino = Nino("AA000003B")
+    val selectionNino: Selection = Selection(ninoIdentifier)
+    val resultData = Payment(LocalDate.parse("2015-04-06"), Some(0), Some(130.99), Some(155.02), Some(100.02), None, None, None, None, None, None, Some(LocalDate.parse("2012-06-22")), Some(130.99))
+    val url = s"/rti/individual/payments/nino/${ninoIdentifier.withoutSuffix}/tax-year/${currentTaxYear.previous.yearForUrl}"
 
-    "successfully obtain data for nino AA000003B" in {
-      val ninoIdentifier: Nino = Nino("AA000003B")
-      val selectionNino: Selection = Selection(ninoIdentifier)
+    "successfully obtain data for a valid NINO" in {
+      stubGetWithResponseBody(url, OK, responseBody)
+      val result: Seq[Payment] = await(connector.getRecords(selectionNino))
 
-      val connector: P45Connector = fakeApplication.injector.instanceOf[P45Connector]
-
-      val result = await(connector.getRecords(selectionNino))
-      result.toList.head shouldBe Payment(paymentDate, Some(0), Some(130.99), Some(155.02), Some(100.02), leavingDate = Some(LocalDate.parse("2012-06-22", ISO_LOCAL_DATE)), totalTaxYTD = Some(130.99))
+      result shouldBe List(resultData)
     }
 
-    "successfully obtain data for nino AA000045A" in {
-      val ninoIdentifier: Nino = Nino("AA000045A")
-      val selectionNino: Selection = Selection(ninoIdentifier)
+    "return empty Seq() AND warnLogs if no NINO is given" in {
+      withCaptureOfLoggingFrom[P45Connector] { logs =>
+        stubGetWithResponseBody(url, OK, responseBody)
+        val payeRef: EmpRef = EmpRef("fakeTaxOfficeNumber", "fakeTaxOfficeReference")
+        val selectionPayeRef: Selection = Selection(payeRef)
+        val result: Seq[Payment] = await(connector.getRecords(selectionPayeRef))
 
-      val connector : P45Connector = fakeApplication.injector.instanceOf[P45Connector]
+        result shouldBe Seq.empty
 
-      val result = await(connector.getRecords(selectionNino))
-
-      result.toList.head shouldBe Payment(paymentDate, Some(45.99), Some(130.99), Some(155.02), Some(100.02), leavingDate = Some(LocalDate.parse("2013-06-22", ISO_LOCAL_DATE)), totalTaxYTD = Some(145.99))
+        val warnLogs = logs.filter(_.getLevel == Level.WARN)
+        warnLogs.size shouldBe 1
+        warnLogs.head.getMessage should include (s"p45Service, No nino identifier for selection: $selectionPayeRef")
+      }
     }
 
-    "return UpstreamErrorResponse when P45 data not found for nino AA002099B" in {
-      val ninoIdentifier: Nino = Nino("AA002099B")
-      val selectionNino: Selection = Selection(ninoIdentifier)
+    "return UpstreamErrorResponse and empty Seq() when P45 data not found" in {
+      withCaptureOfLoggingFrom[P45Connector] { logs =>
+        stubGetWithResponseBody(url, NOT_FOUND, responseBody)
+        val result: Seq[Payment] = await(connector.getRecords(selectionNino))
+        result shouldBe Seq.empty
 
-      val connector: P45Connector = fakeApplication.injector.instanceOf[P45Connector]
-      val result = await(connector.getRecords(selectionNino))
-      result shouldBe Seq[Payment]()
+        val infoLogs = logs.filter(_.getLevel == Level.INFO)
+        infoLogs.size shouldBe 1
+        infoLogs.head.getMessage should include ("p45Service is not available for user:")
+      }
     }
   }
 }

--- a/it/test/connectors/p60/P60ConnectorISpec.scala
+++ b/it/test/connectors/p60/P60ConnectorISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package test.connectors.p60
+package connectors.p60
 
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
-import test.iUtils.BaseISpec
-import uk.gov.hmrc.domain.Nino
+import ch.qos.logback.classic.Level
+import iUtils.{BaseISpec, LogCapturing, TestTaxYearBuilder, WireMockStubs}
+import play.api.libs.json.Json
+import uk.gov.hmrc.domain.{EmpRef, Nino}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.identityverificationquestions.models.Selection
 import uk.gov.hmrc.identityverificationquestions.models.payment.Payment
@@ -30,23 +30,117 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class P60ConnectorISpec extends BaseISpec {
+class P60ConnectorISpec extends BaseISpec with LogCapturing with WireMockStubs with TestTaxYearBuilder {
 
   def await[A](future: Future[A]): A = Await.result(future, 50.second)
-  override lazy val fakeApplication: Application = new GuiceApplicationBuilder().build()
+
+  private val jsonParse: String =
+    """
+      |{
+      |  "individual": {
+      |    "employments": {
+      |      "employment": [
+      |        {
+      |          "payments": {
+      |            "inYear": [
+      |              {
+      |                "payId": "65553-1808",
+      |                "payFreq": "IO",
+      |                "mandatoryMonetaryAmount": [
+      |                  {
+      |                    "type": "TaxablePayYTD",
+      |                    "amount": 0
+      |                  },
+      |                  {
+      |                    "type": "TaxablePay",
+      |                    "amount": 102.02
+      |                  },
+      |                  {
+      |                    "type": "TotalTaxYTD",
+      |                    "amount": 120.99
+      |                  },
+      |                  {
+      |                    "type": "TaxDeductedOrRefunded",
+      |                    "amount": 155.02
+      |                  }
+      |                ],
+      |                "niLettersAndValues": [
+      |                  {
+      |                    "niFigure": [
+      |                      {
+      |                        "type": "EmpeeContribnsInPd",
+      |                        "amount": 100.02
+      |                      },
+      |                      {
+      |                        "type": "EmpeeContribnsYTD",
+      |                        "amount": 0
+      |                      },
+      |                      {
+      |                        "type": "PTtoUELYTD",
+      |                        "amount": 0
+      |                      }
+      |                    ]
+      |                  }
+      |                ],
+      |                "optionalMonetaryAmount": [
+      |                  {
+      |                    "type": "SMPYTD",
+      |                    "amount": 300.02
+      |                  },
+      |                  {
+      |                    "type": "StudentLoansYTD",
+      |                    "amount": 800.02
+      |                  },
+      |                  {
+      |                    "type": "SPBYTD",
+      |                    "amount": 0
+      |                  },
+      |                  {
+      |                    "type": "SPPYTD",
+      |                    "amount": 0
+      |                  },
+      |                  {
+      |                    "type": "SHPPYTD",
+      |                    "amount": 0
+      |                  },
+      |                  {
+      |                    "type": "PostGraduateLoansYTD",
+      |                    "amount": 0
+      |                  },
+      |                  {
+      |                    "type": "SAPYTD",
+      |                    "amount": 0
+      |                  }
+      |                ],
+      |                "starter": {
+      |                  "startDate": "2013-09-07"
+      |                },
+      |                "pmtDate": "2015-04-06",
+      |                "rcvdDate": "2015-04-06",
+      |                "taxYear": "15-16"
+      |              }
+      |            ]
+      |          },
+      |          "sequenceNumber": 16
+      |        }
+      |      ]
+      |    }
+      |  }
+      |}
+      |""".stripMargin
+  private val responseBody: String = Json.parse(jsonParse).toString()
 
   "get p60 returns" should {
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    val paymentDate: LocalDate = LocalDate.now().minusMonths(1).minusDays(25)
+    lazy val connector: P60Connector = app.injector.instanceOf[P60Connector]
+    val ninoIdentifier: Nino = Nino("AA002022B")
+    val selectionNino: Selection = Selection(ninoIdentifier)
+    val url = s"/rti/individual/payments/nino/${ninoIdentifier.withoutSuffix}/tax-year/${currentTaxYear.previous.yearForUrl}"
 
-    "successfully obtain data for nino AA002022B" in {
-      val ninoIdentifier: Nino = Nino("AA002022B")
-      val selectionNino: Selection = Selection(ninoIdentifier)
-
-      val connector: P60Connector = fakeApplication.injector.instanceOf[P60Connector]
-
-      val result = await(connector.getRecords(selectionNino))
-      result.toList.head shouldBe Payment(paymentDate, Some(0), Some(0), Some(155.02), Some(100.02),
+    "successfully obtain data for valid NINO" in {
+      stubGetWithResponseBody(url, OK, responseBody)
+      val result: Seq[Payment] = await(connector.getRecords(selectionNino))
+      result.toList.head shouldBe Payment(LocalDate.parse("2015-04-06"), Some(0), Some(0), Some(155.02), Some(100.02),
                                           earningsAbovePT = Some(0),
                                           statutoryMaternityPay = Some(300.02),
                                           statutorySharedParentalPay = Some(0),
@@ -56,47 +150,31 @@ class P60ConnectorISpec extends BaseISpec {
                                           totalTaxYTD = Some(120.99))
     }
 
-    "successfully obtain data for nino AA002023B" in {
-      val ninoIdentifier: Nino = Nino("AA002023B")
-      val selectionNino: Selection = Selection(ninoIdentifier)
+    "return empty Seq() AND warnLogs if no NINO is given" in {
+      withCaptureOfLoggingFrom[P60Connector] { logs =>
+        stubGetWithResponseBody(url, OK, responseBody)
+        val payeRef: EmpRef = EmpRef("fakeTaxOfficeNumber", "fakeTaxOfficeReference")
+        val selectionPayeRef: Selection = Selection(payeRef)
+        val result: Seq[Payment] = await(connector.getRecords(selectionPayeRef))
 
-      val connector : P60Connector = fakeApplication.injector.instanceOf[P60Connector]
+        result shouldBe Seq.empty
 
-      val result = await(connector.getRecords(selectionNino))
-
-      result.toList.head shouldBe Payment(paymentDate, Some(0), Some(0), Some(155.02), Some(100.02),
-                                          earningsAbovePT = Some(0),
-                                          statutoryMaternityPay = Some(0),
-                                          statutorySharedParentalPay = Some(0),
-                                          statutoryAdoptionPay = Some(400.02),
-                                          studentLoanDeductions = Some(0),
-                                          postgraduateLoanDeductions = Some(300.02),
-                                          totalTaxYTD = Some(120.99))
+        val warnLogs = logs.filter(_.getLevel == Level.WARN)
+        warnLogs.size shouldBe 1
+        warnLogs.head.getMessage should include (s"p60Service, No nino identifier for selection: $selectionPayeRef")
+      }
     }
-    "successfully obtain data for nino AA002024B" in {
-      val ninoIdentifier: Nino = Nino("AA002024B")
-      val selectionNino: Selection = Selection(ninoIdentifier)
 
-      val connector : P60Connector = fakeApplication.injector.instanceOf[P60Connector]
+    "return UpstreamErrorResponse and empty Seq() when P60 data not found" in {
+      withCaptureOfLoggingFrom[P60Connector] { logs =>
+        stubGetWithResponseBody(url, NOT_FOUND, responseBody)
+        val result: Seq[Payment] = await(connector.getRecords(selectionNino))
+        result shouldBe Seq.empty
 
-      val result = await(connector.getRecords(selectionNino))
-
-      result.toList.head shouldBe Payment(paymentDate, Some(0), Some(0), Some(155.02), Some(100.02),
-                                          earningsAbovePT = Some(200.02),
-                                          statutoryMaternityPay = Some(0),
-                                          statutorySharedParentalPay = Some(500.02),
-                                          statutoryAdoptionPay = Some(0),
-                                          studentLoanDeductions = Some(0),
-                                          postgraduateLoanDeductions = Some(0),
-                                          totalTaxYTD = Some(120.99))
-    }
-    "return UpstreamErrorResponse when P60 data not found for nino AA002099B" in {
-      val ninoIdentifier: Nino = Nino("AA002099B")
-      val selectionNino: Selection = Selection(ninoIdentifier)
-
-      val connector: P60Connector = fakeApplication.injector.instanceOf[P60Connector]
-      val result = await(connector.getRecords(selectionNino))
-      result shouldBe Seq[Payment]()
+        val infoLogs = logs.filter(_.getLevel == Level.INFO)
+        infoLogs.size shouldBe 1
+        infoLogs.head.getMessage should include ("p60Service is not available for user:")
+      }
     }
   }
 }

--- a/it/test/connectors/payslip/PayslipConnectorISpec.scala
+++ b/it/test/connectors/payslip/PayslipConnectorISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,40 +14,131 @@
  * limitations under the License.
  */
 
-package test.connectors.payslip
+package connectors.payslip
 
-import java.time.LocalDate
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
-import test.iUtils.BaseISpec
-import uk.gov.hmrc.domain.Nino
+import ch.qos.logback.classic.Level
+import iUtils.{BaseISpec, LogCapturing, TestTaxYearBuilder, WireMockStubs}
+import play.api.libs.json.Json
+import uk.gov.hmrc.domain.{EmpRef, Nino}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.identityverificationquestions.models.Selection
 import uk.gov.hmrc.identityverificationquestions.models.payment.Payment
 import uk.gov.hmrc.identityverificationquestions.sources.payslip.PayslipConnector
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class PayslipConnectorISpec extends BaseISpec {
+class PayslipConnectorISpec extends BaseISpec with LogCapturing with WireMockStubs with TestTaxYearBuilder {
 
   def await[A](future: Future[A]): A = Await.result(future, 50.second)
 
-  override lazy val fakeApplication: Application = new GuiceApplicationBuilder().build()
+  private val paymentDate: LocalDate = LocalDate.now().minusMonths(1).minusDays(25)
+  private val jsonParse: String =
+    s"""
+      |{
+      |  "individual": {
+      |    "employments": {
+      |      "employment": [
+      |        {
+      |          "payments": {
+      |            "inYear": [
+      |              {
+      |                "payId": "20425",
+      |                "leavingDate": "2012-06-22",
+      |                "payFreq": "IO",
+      |                "mandatoryMonetaryAmount": [
+      |                  {
+      |                    "type": "TaxablePayYTD",
+      |                    "amount": 0
+      |                  },
+      |                  {
+      |                    "type": "TaxablePay",
+      |                    "amount": 102.02
+      |                  },
+      |                  {
+      |                    "type": "TotalTaxYTD",
+      |                    "amount": 130.99
+      |                  },
+      |                  {
+      |                    "type": "TaxDeductedOrRefunded",
+      |                    "amount": 155.02
+      |                  }
+      |                ],
+      |                "niLettersAndValues": [
+      |                  {
+      |                    "niFigure": [
+      |                      {
+      |                        "type": "EmpeeContribnsInPd",
+      |                        "amount": 100.02
+      |                      },
+      |                      {
+      |                        "type": "EmpeeContribnsYTD",
+      |                        "amount": 130.99
+      |                      }
+      |                    ]
+      |                  }
+      |                ],
+      |                "starter": {
+      |                  "startDate": "2011-08-13"
+      |                },
+      |                "pmtDate": "$paymentDate",
+      |                "rcvdDate": "2015-04-06",
+      |                "taxYear": "14-15"
+      |              }
+      |            ]
+      |          }
+      |        }
+      |      ]
+      |    }
+      |  }
+      |}
+      |""".stripMargin
+  private val responseBody: String = Json.parse(jsonParse).toString()
 
   "get payslip returns" should {
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    val paymentDate: LocalDate = LocalDate.now().minusMonths(1).minusDays(25)
+    lazy val connector: PayslipConnector = app.injector.instanceOf[PayslipConnector]
 
-    "successfully obtain data for nino AA000003D" in {
-      val ninoIdentifier: Nino = Nino("AA000003D")
-      val selectionNino: Selection = Selection(ninoIdentifier)
+    val ninoIdentifier: Nino = Nino("AA000003D")
+    val selectionNino: Selection = Selection(ninoIdentifier)
+    val url = s"/rti/individual/payments/nino/${ninoIdentifier.withoutSuffix}/tax-year/${currentTaxYear.yearForUrl}"
 
-      val connector: PayslipConnector = fakeApplication.injector.instanceOf[PayslipConnector]
+    "successfully obtain data for valid NINO" in {
+      stubGetWithResponseBody(url, OK, responseBody)
+      val result: Seq[Payment] = await(connector.getRecords(selectionNino))
 
-      val result = await(connector.getRecords(selectionNino))
-      result.toList.head shouldBe Payment(paymentDate, Some(3000), Some(120.99), Some(155.02), Some(100.02), None, None, None, None, None, None, totalTaxYTD = Some(120.99))
+      println("Local Date = " + LocalDate.now().minusMonths(1).minusDays(25))
+
+      result shouldBe List(Payment(paymentDate, Some(0), Some(130.99), Some(155.02), Some(100.02), None, None, None, None, None, None, Some(LocalDate.parse("2012-06-22")), Some(130.99)))
+    }
+
+    "return empty Seq() AND warnLogs if no NINO is given" in {
+      withCaptureOfLoggingFrom[PayslipConnector] { logs =>
+        stubGetWithResponseBody(url, OK, responseBody)
+        val payeRef: EmpRef = EmpRef("fakeTaxOfficeNumber", "fakeTaxOfficeReference")
+        val selectionPayeRef: Selection = Selection(payeRef)
+        val result: Seq[Payment] = await(connector.getRecords(selectionPayeRef))
+
+        result shouldBe Seq.empty
+
+        val warnLogs = logs.filter(_.getLevel == Level.WARN)
+        warnLogs.size shouldBe 1
+        warnLogs.head.getMessage should include (s"payslipService, No nino identifier for selection: $selectionPayeRef")
+      }
+    }
+
+    "return UpstreamErrorResponse and empty Seq() when P60 data not found" in {
+      withCaptureOfLoggingFrom[PayslipConnector] { logs =>
+        stubGetWithResponseBody(url, NOT_FOUND, responseBody)
+        val result: Seq[Payment] = await(connector.getRecords(selectionNino))
+        result shouldBe Seq.empty
+
+        val infoLogs = logs.filter(_.getLevel == Level.INFO)
+        infoLogs.size shouldBe 1
+        infoLogs.head.getMessage should include ("payslipService is not available for user:")
+      }
     }
   }
 }

--- a/it/test/connectors/sa/SAPensionsConnectorISpec.scala
+++ b/it/test/connectors/sa/SAPensionsConnectorISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,34 +14,159 @@
  * limitations under the License.
  */
 
-package test.connectors.sa
+package connectors.sa
 
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
-import test.iUtils.BaseISpec
+import iUtils.{BaseISpec, WireMockStubs}
+import play.api.libs.json.Json
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.identityverificationquestions.services.utilities.TaxYear
 import uk.gov.hmrc.identityverificationquestions.sources.sa.{SAPensionsConnector, SARecord, SAReturn}
 
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class SAPensionsConnectorISpec extends BaseISpec {
+class SAPensionsConnectorISpec extends BaseISpec with WireMockStubs {
 
   def await[A](future: Future[A]): A = Await.result(future, 50.second)
-  override lazy val fakeApplication: Application = new GuiceApplicationBuilder().build()
+
+  private val jsonParse: String =
+    s"""
+       |[
+       |  {
+       |    "income": 65535,
+       |    "returnList": [
+       |      {
+       |        "utr": "1234567890",
+       |        "addressLine1": "123 Fake Street",
+       |        "addressLine2": "Fake Town",
+       |        "addressLine3": "",
+       |        "addressLine4": "",
+       |        "postalCode": "SW1A 1AA",
+       |        "addressTypeIndicator": "B",
+       |        "baseAddressEffectivetDate": "2020-01-01",
+       |        "caseStartDate": "2020-01-01",
+       |        "receivedDate": "2020-01-01",
+       |        "sourceStartDate": "2020-01-01",
+       |        "businessDescription": "Shenanigans",
+       |        "codedInLaterYear": 1,
+       |        "dividendTaxCredits": 2,
+       |        "foreignTaxOnEstates": 3,
+       |        "giftExtender": 4,
+       |        "giftInvestmentsAndPropertyToCharity": 5,
+       |        "grossAnnuityPayments": 6,
+       |        "incomeFromAllEmployments": 7,
+       |        "incomeFromForeign4Sources": 8,
+       |        "incomeFromForeignDividends": 9,
+       |        "incomeFromGainsOnLifePolicies": 10,
+       |        "incomeFromInterestNDividendsFromUKCompaniesNTrusts": 11,
+       |        "incomeFromOther": 12,
+       |        "incomeFromPensions": 2020.13,
+       |        "incomeFromProperty": 14,
+       |        "incomeFromSelfAssessment": 15,
+       |        "incomeFromSharesOptions": 16,
+       |        "incomeFromTrust": 17,
+       |        "incomeFromUkInterest": 18,
+       |        "incomeTaxReliefReduced": 19,
+       |        "incomeTotalWhereTaxIsDue": 20,
+       |        "paymentsRetirementAnnuityContract": 21,
+       |        "pprExtender": 22,
+       |        "profitFromPartnerships": 23,
+       |        "profitFromSelfEmployment": 24,
+       |        "taxCreditsForeignDividends": 25,
+       |        "taxSolvencyStatus": "S",
+       |        "totalCapitalGainsDue": 26,
+       |        "totalCapitalGainsTaxDue": 27,
+       |        "totalIncomeTaxAndCapitalGainsAndNic4Contributions": 28,
+       |        "totalIncomeTaxAndNic4Contributions": 29,
+       |        "totalTaxAndNic4ContributionsDue": 30,
+       |        "totalTaxPaid": 31,
+       |        "telephoneNumber": "01234567890"
+       |      }
+       |    ],
+       |    "taxYear": "2020"
+       |  },
+       |  {
+       |    "income": 65535,
+       |    "returnList": [
+       |      {
+       |        "utr": "1234567890",
+       |        "addressLine1": "123 Fake Street",
+       |        "addressLine2": "Fake Town",
+       |        "addressLine3": "",
+       |        "addressLine4": "",
+       |        "postalCode": "SW1A 1AA",
+       |        "addressTypeIndicator": "B",
+       |        "baseAddressEffectivetDate": "2020-01-01",
+       |        "caseStartDate": "2020-01-01",
+       |        "receivedDate": "2020-01-01",
+       |        "sourceStartDate": "2020-01-01",
+       |        "businessDescription": "Shenanigans",
+       |        "codedInLaterYear": 1,
+       |        "dividendTaxCredits": 2,
+       |        "foreignTaxOnEstates": 3,
+       |        "giftExtender": 4,
+       |        "giftInvestmentsAndPropertyToCharity": 5,
+       |        "grossAnnuityPayments": 6,
+       |        "incomeFromAllEmployments": 7,
+       |        "incomeFromForeign4Sources": 8,
+       |        "incomeFromForeignDividends": 9,
+       |        "incomeFromGainsOnLifePolicies": 10,
+       |        "incomeFromInterestNDividendsFromUKCompaniesNTrusts": 11,
+       |        "incomeFromOther": 12,
+       |        "incomeFromPensions": 2019.13,
+       |        "incomeFromProperty": 14,
+       |        "incomeFromSelfAssessment": 15,
+       |        "incomeFromSharesOptions": 16,
+       |        "incomeFromTrust": 17,
+       |        "incomeFromUkInterest": 18,
+       |        "incomeTaxReliefReduced": 19,
+       |        "incomeTotalWhereTaxIsDue": 20,
+       |        "paymentsRetirementAnnuityContract": 21,
+       |        "pprExtender": 22,
+       |        "profitFromPartnerships": 23,
+       |        "profitFromSelfEmployment": 24,
+       |        "taxCreditsForeignDividends": 25,
+       |        "taxSolvencyStatus": "S",
+       |        "totalCapitalGainsDue": 26,
+       |        "totalCapitalGainsTaxDue": 27,
+       |        "totalIncomeTaxAndCapitalGainsAndNic4Contributions": 28,
+       |        "totalIncomeTaxAndNic4Contributions": 29,
+       |        "totalTaxAndNic4ContributionsDue": 30,
+       |        "totalTaxPaid": 31,
+       |        "telephoneNumber": "01234567890"
+       |      }
+       |    ],
+       |    "taxYear": "2019"
+       |  }
+       |]
+       |""".stripMargin
+  private val responseBody: String = Json.parse(jsonParse).toString()
 
   "get sa returns" should {
-    "successfully obtain a return" in {
-      implicit val hc: HeaderCarrier = HeaderCarrier()
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    lazy val connector : SAPensionsConnector = app.injector.instanceOf[SAPensionsConnector]
 
-      val connector : SAPensionsConnector = fakeApplication.injector.instanceOf[SAPensionsConnector]
+    val ninoIdentifier: Nino = Nino("AA000003D")
+    val startYear = 2019
+    val endYear = 2019
+    val url = s"/individuals/nino/$ninoIdentifier/self-assessment/income\\?startYear=${startYear.toString}&endYear=${endYear.toString}"
 
-      val result: Seq[SAReturn] = await(connector.getReturns(Nino("AA000003D"), 2019, 2019))
+    "successfully obtain a record for valid NINO" in {
+      stubGetWithResponseBody(url, OK, responseBody)
+      val result: Seq[SAReturn] = await(connector.getReturns(ninoIdentifier, startYear, endYear))
 
-      result shouldBe List(SAReturn(TaxYear(2019), List(SARecord(BigDecimal(15), BigDecimal(2019.13)))))
+      result shouldBe List(
+        SAReturn(TaxYear(2020), List(SARecord(BigDecimal(15), BigDecimal(2020.13)))),
+        SAReturn(TaxYear(2019), List(SARecord(BigDecimal(15), BigDecimal(2019.13))))
+      )
+    }
+
+    "return UpstreamErrorResponse and empty Seq() when P60 data not found" in {
+      stubGetWithResponseBody(url, NOT_FOUND, responseBody)
+      val result: Seq[SAReturn] = await(connector.getReturns(ninoIdentifier, startYear, endYear))
+      result shouldBe Seq.empty
     }
   }
 

--- a/it/test/controllers/AnswerControllerISpec.scala
+++ b/it/test/controllers/AnswerControllerISpec.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package test.controllers
+package controllers
 
 import play.api.libs.json.{JsString, JsSuccess, Json}
 import play.api.libs.ws.WSResponse
-import test.iUtils.BaseISpec
+import iUtils.BaseISpec
 import uk.gov.hmrc.domain.{Nino, SaUtr}
 import uk.gov.hmrc.identityverificationquestions.models.P60.{EmployeeNIContributions, PaymentToDate}
 import uk.gov.hmrc.identityverificationquestions.models._

--- a/it/test/controllers/QuestionControllerISpec.scala
+++ b/it/test/controllers/QuestionControllerISpec.scala
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package test.controllers
+package controllers
 
 import ch.qos.logback.classic.Level
 import org.scalatestplus.play.BaseOneServerPerSuite
 import play.api.libs.json.{JsObject, JsResult, Json}
 import play.api.libs.ws.WSResponse
-import test.iUtils.{BaseISpec, LogCapturing, WireMockStubs}
-import test.iUtils.TestData.RtiTestData
+import iUtils.{BaseISpec, LogCapturing, WireMockStubs}
+import iUtils.TestData.RtiTestData
 import uk.gov.hmrc.identityverificationquestions.config.AppConfig
 import uk.gov.hmrc.identityverificationquestions.models.P60.{EmployeeNIContributions, PaymentToDate}
 import uk.gov.hmrc.identityverificationquestions.models._
@@ -72,7 +72,7 @@ class QuestionControllerISpec extends BaseISpec with LogCapturing with BaseOneSe
         questionResponse.isSuccess shouldBe true
         questionResponse.get.questions should not contain paymentToDateQuestion
         questionResponse.get.questions should not contain employeeNIContributionsQuestion
-        logs.filter(_.getLevel == Level.ERROR).count(_.getMessage.contains("p60Service threw Exception, origin: identity-verification; detail: uk.gov.hmrc.http.Upstream5xxResponse")) shouldBe 1
+        logs.filter(_.getLevel == Level.ERROR).count(_.getMessage.contains("p60Service threw Exception, origin: identity-verification; detail: uk.gov.hmrc.http.UpstreamErrorResponse")) shouldBe 1
       }
     }
 

--- a/it/test/iUtils/BaseISpec.scala
+++ b/it/test/iUtils/BaseISpec.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package test.iUtils
+package iUtils
 
-import com.github.tomakehurst.wiremock.client.WireMock.{ok, post, stubFor, urlPathEqualTo}
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.http.{HeaderNames, Status}
@@ -28,8 +27,8 @@ import play.api.libs.ws.{WSClient, WSRequest}
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits, Injecting}
 import uk.gov.hmrc.identityverificationquestions.repository.QuestionMongoRepository
 
-import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME
+import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 
 trait BaseISpec extends AnyWordSpecLike
   with Matchers
@@ -77,10 +76,6 @@ trait BaseISpec extends AnyWordSpecLike
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    stubFor(
-      post(urlPathEqualTo("/platform-analytics/event"))
-        .willReturn(ok())
-    )
     await(identityverificationquestions.collection.drop().toFuture())
   }
 

--- a/it/test/iUtils/LogCapturing.scala
+++ b/it/test/iUtils/LogCapturing.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package test.iUtils
+package iUtils
 
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Level, Logger => LogbackLogger}

--- a/it/test/iUtils/TestData/RtiTestData.scala
+++ b/it/test/iUtils/TestData/RtiTestData.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package test.iUtils.TestData
+package iUtils.TestData
 
 import play.api.libs.json.Json
 

--- a/it/test/iUtils/TestData/SCPEmailTestData.scala
+++ b/it/test/iUtils/TestData/SCPEmailTestData.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package test.iUtils.TestData
+package iUtils.TestData
 
 import play.api.libs.json.{JsValue, Json}
 

--- a/it/test/iUtils/TestTaxYearBuilder.scala
+++ b/it/test/iUtils/TestTaxYearBuilder.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iUtils
+
+import uk.gov.hmrc.identityverificationquestions.services.utilities.TaxYear
+
+import java.time.LocalDate
+
+trait TestTaxYearBuilder {
+
+  val startingDayForTaxYear = 6
+  val startingMonthForTaxYear = 4
+
+  def today: LocalDate = LocalDate.now
+
+  def currentYear = today.getYear
+
+  def startOfTheTaxYear = LocalDate.of(currentYear, startingMonthForTaxYear, startingDayForTaxYear)
+
+  /**
+   *
+   * @param bufferInMonths the number of months after the start of current tax year while we still look at the old one
+   * @return the current tax year - deferred a bit.
+   */
+  def currentTaxYearWithBuffer(bufferInMonths: Int) =
+    currentTaxYear(startOfTheTaxYear.plusMonths(bufferInMonths))
+
+  private def currentTaxYear(logicalStartOfYear: LocalDate): TaxYear = TaxYear(
+    if (today isBefore logicalStartOfYear) currentYear - 1
+    else currentYear
+  )
+
+  def currentTaxYear: TaxYear = currentTaxYear(startOfTheTaxYear)
+}

--- a/it/test/iUtils/WireMockSupport.scala
+++ b/it/test/iUtils/WireMockSupport.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package test.iUtils
+package iUtils
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock

--- a/it/test/monitoring/analytics/AnalyticsConnectorISpec.scala
+++ b/it/test/monitoring/analytics/AnalyticsConnectorISpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monitoring.analytics
+
+import Utils.LogCapturing
+import ch.qos.logback.classic.Level
+import iUtils.{BaseISpec, WireMockStubs}
+import org.apache.pekko.Done
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.identityverificationquestions.monitoring.analytics.{AnalyticsConnector, AnalyticsRequest, DimensionValue, Event}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.DurationInt
+
+class AnalyticsConnectorISpec extends BaseISpec with LogCapturing with WireMockStubs {
+
+  def await[A](future: Future[A]): A = Await.result(future, 50.second)
+  lazy val connector: AnalyticsConnector = app.injector.instanceOf[AnalyticsConnector]
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  private val correctRequest = AnalyticsRequest(Some("TestID"), Seq(Event("", "", "", Seq(DimensionValue(1, "Test")))))
+
+  private val requestBody = Json.toJson(correctRequest).toString()
+  private val url = s"/platform-analytics/event"
+
+  "Analytics Connector" should {
+    "successfully execute a valid request" in {
+      withCaptureOfLoggingFrom[AnalyticsConnector] { logs =>
+        stubPostWithoutResponseBody(url, OK, requestBody)
+        val result = await(connector.sendEvent(correctRequest))
+        result shouldBe Done
+
+        val errorLogs = logs.filter(_.getLevel == Level.ERROR)
+        errorLogs.size shouldBe 0
+      }
+    }
+
+    "return an error log if no response received" in {
+      withCaptureOfLoggingFrom[AnalyticsConnector] { logs =>
+        stubPostWithError(url, requestBody)
+        val result = await(connector.sendEvent(correctRequest))
+        result shouldBe Done
+
+        val errorLogs = logs.filter(_.getLevel == Level.ERROR)
+        errorLogs.size shouldBe 1
+        errorLogs.head.getMessage should include ("Couldn't send analytics event AnalyticsRequest")
+      }
+    }
+  }
+
+}

--- a/it/test/monitoring/auditing/AuditServiceISpec.scala
+++ b/it/test/monitoring/auditing/AuditServiceISpec.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package monitoring
+package monitoring.auditing
 
 import org.mockito.MockitoSugar.mock
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{JsError, JsSuccess, JsValue, Json, OFormat}
+import play.api.libs.json._
 import play.api.test.FakeRequest
-import test.iUtils.BaseISpec
+import iUtils.BaseISpec
 import uk.gov.hmrc.domain.{EmpRef, Nino, SaUtr}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.identityverificationquestions.models.Payslip.NationalInsurance
-import uk.gov.hmrc.identityverificationquestions.models.{AnswerDetails, CorrelationId, QuestionDataCache, QuestionWithAnswers, Score, Selection, SimpleAnswer}
+import uk.gov.hmrc.identityverificationquestions.models._
 import uk.gov.hmrc.identityverificationquestions.monitoring.auditing.AuditService
 
 import java.time.Instant

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "8.6.0"
+  private val bootstrapPlayVersion = "9.16.0"
   private val mongoVersion = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
@@ -14,9 +14,9 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-30"     % bootstrapPlayVersion  % Test,
-    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30"    % mongoVersion          % Test,
-    "org.mockito"             %% "mockito-scala-scalatest"    % "1.17.37"             % Test,
-    "org.scalamock"           %% "scalamock"                  % "6.0.0"               % Test
-  )
+    "uk.gov.hmrc"             %% "bootstrap-test-play-30"     % bootstrapPlayVersion,
+    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30"    % mongoVersion,
+    "org.mockito"             %% "mockito-scala-scalatest"    % "2.0.0",
+    "org.scalamock"           %% "scalamock"                  % "7.4.0"
+  ).map(_ % "test")
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,6 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.7")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.8")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.3.1")
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.6.4")

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sbt coverage test it/test coverageReport dependencyUpdates

--- a/test/mocks/MockHttpClientV2.scala
+++ b/test/mocks/MockHttpClientV2.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks
+
+import org.scalamock.handlers.{CallHandler1, CallHandler2}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.TestSuite
+import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReads}
+
+import java.net.URL
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockHttpClientV2 extends MockFactory { this: TestSuite =>
+  val mockHttpClientV2: HttpClientV2 = mock[HttpClientV2]
+  val mockRequestBuilder: RequestBuilder = mock[RequestBuilder]
+
+  def mockHttpClientV2Get(url: URL): CallHandler2[URL, HeaderCarrier, RequestBuilder] =
+    (mockHttpClientV2
+      .get(_ : URL)(_: HeaderCarrier))
+      .expects(url, *)
+      .returning(mockRequestBuilder)
+
+  def mockHttpClientV2SetHeader(): CallHandler1[(String, String), RequestBuilder] =
+    (mockRequestBuilder
+      .setHeader(_: (String, String)))
+      .expects(*)
+      .returning(mockRequestBuilder)
+
+  def mockHttpClientV2Execute[O: HttpReads](response: O): CallHandler2[HttpReads[O], ExecutionContext, Future[O]] =
+    (mockRequestBuilder
+      .execute(_: HttpReads[O], _: ExecutionContext))
+      .expects(*, *)
+      .returning(Future.successful(response))
+
+  def mockHttpClientV2ExecuteException[O: HttpReads](response: Throwable): CallHandler2[HttpReads[O], ExecutionContext, Future[O]] =
+    (mockRequestBuilder
+      .execute(_: HttpReads[O], _: ExecutionContext))
+      .expects(*, *)
+      .returning(Future.failed(response))
+
+}

--- a/test/uk/gov/hmrc/identityverificationquestions/models/payment/PaymentSpec.scala
+++ b/test/uk/gov/hmrc/identityverificationquestions/models/payment/PaymentSpec.scala
@@ -17,12 +17,15 @@
 package uk.gov.hmrc.identityverificationquestions.models.payment
 
 import Utils.UnitSpec
-import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.json.{JsSuccess, JsValue, Json}
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE  //   ISO_LOCAL_DATE_TIME
 
 class PaymentSpec extends UnitSpec {
+
+  val validPayment: Payment = Payment(LocalDate.parse("2014-06-28", ISO_LOCAL_DATE), Some(100.01), Some(34.82), Some(10), Some(12.34), leavingDate = Some(LocalDate.parse("2012-06-22", ISO_LOCAL_DATE)), totalTaxYTD = Some(10.10))
+
   "deserializing valid json" should {
     "create an Payment object" in new Setup {
       validPaymentJson.validate[Payment] shouldBe JsSuccess(validPayment)
@@ -30,7 +33,7 @@ class PaymentSpec extends UnitSpec {
   }
 
   trait Setup {
-    val validPaymentJson = Json.parse(
+    val validPaymentJson: JsValue = Json.parse(
       """
         |{
         |  "payId": "20425",
@@ -78,6 +81,4 @@ class PaymentSpec extends UnitSpec {
         |""".stripMargin
     )
   }
-  val validPayment = Payment(LocalDate.parse("2014-06-28", ISO_LOCAL_DATE), Some(100.01), Some(34.82), Some(10), Some(12.34), leavingDate = Some(LocalDate.parse("2012-06-22", ISO_LOCAL_DATE)), totalTaxYTD = Some(10.10))
-
 }

--- a/test/uk/gov/hmrc/identityverificationquestions/services/AnswerServiceSpec.scala
+++ b/test/uk/gov/hmrc/identityverificationquestions/services/AnswerServiceSpec.scala
@@ -76,7 +76,7 @@ class AnswerServiceSpec extends UnitSpec with LogCapturing {
             service.checkAnswers(AnswerCheck(correlationId, Seq(paymentToDateAnswer, EmployeeNIContributionsAnswer), None),paymentToDateAnswer).futureValue shouldBe Seq(QuestionResult(PaymentToDate, Unknown))
             val errorLogs = logs.filter(_.getLevel == Level.ERROR)
             errorLogs.size shouldBe 1
-            errorLogs.head.getMessage shouldBe s"p60Service, when check answers threw exception uk.gov.hmrc.http.Upstream4xxResponse: bad bad bad request, correlationId: ${correlationId.id}"
+            errorLogs.head.getMessage shouldBe s"p60Service, when check answers threw exception uk.gov.hmrc.http.UpstreamErrorResponse: bad bad bad request, correlationId: ${correlationId.id}"
           }
         }
 

--- a/test/uk/gov/hmrc/identityverificationquestions/services/QuestionServiceSpec.scala
+++ b/test/uk/gov/hmrc/identityverificationquestions/services/QuestionServiceSpec.scala
@@ -73,14 +73,14 @@ class QuestionServiceSpec extends UnitSpec with LogCapturing {
       "return true" when {
         "The user-agent is not on the denied list for p60" in new Setup {
           (mockAppConfig.deniedUserAgentListForP60 _).expects().returning(Seq("identity-verification"))
-          service.isUserAllowed("lost-credentials") shouldBe (true)
+          service.isUserAllowed("lost-credentials") shouldBe true
         }
       }
 
       "return false" when {
         "The user-agent is on the denied list for p60" in new Setup {
           (mockAppConfig.deniedUserAgentListForP60 _).expects().returning(Seq("identity-verification"))
-          service.isUserAllowed("identity-verification") shouldBe (false)
+          service.isUserAllowed("identity-verification") shouldBe false
         }
       }
     }
@@ -95,7 +95,7 @@ class QuestionServiceSpec extends UnitSpec with LogCapturing {
             service.questions(Selection(ninoIdentifier, saUtrIdentifier), corrId).futureValue shouldBe Seq()
             val errorLogs = logs.filter(_.getLevel == Level.ERROR)
             errorLogs.size shouldBe 1
-            errorLogs.head.getMessage shouldBe "p60Service threw Exception, origin: origin; detail: uk.gov.hmrc.http.Upstream4xxResponse: bad bad bad request"
+            errorLogs.head.getMessage shouldBe "p60Service threw Exception, origin: origin; detail: uk.gov.hmrc.http.UpstreamErrorResponse: bad bad bad request"
           }
         }
 
@@ -107,7 +107,7 @@ class QuestionServiceSpec extends UnitSpec with LogCapturing {
             service.questions(Selection(ninoIdentifier, saUtrIdentifier), corrId).futureValue shouldBe Seq()
             val errorLogs = logs.filter(_.getLevel == Level.ERROR)
             errorLogs.size shouldBe 1
-            errorLogs.head.getMessage shouldBe "p60Service threw Exception, origin: origin; detail: uk.gov.hmrc.http.Upstream5xxResponse: internal server error"
+            errorLogs.head.getMessage shouldBe "p60Service threw Exception, origin: origin; detail: uk.gov.hmrc.http.UpstreamErrorResponse: internal server error"
           }
         }
 

--- a/test/uk/gov/hmrc/identityverificationquestions/sources/P45/P45ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/identityverificationquestions/sources/P45/P45ConnectorSpec.scala
@@ -16,31 +16,34 @@
 
 package uk.gov.hmrc.identityverificationquestions.sources.P45
 
-import Utils.{LogCapturing, UnitSpec}
-import org.apache.pekko.actor.ActorSystem
 import Utils.testData.P60TestData
+import Utils.{LogCapturing, UnitSpec}
 import ch.qos.logback.classic.Level
-import com.typesafe.config.Config
-import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
-import uk.gov.hmrc.http.hooks.HttpHook
+import mocks.MockHttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.identityverificationquestions.config.{AppConfig, HodConf}
+import uk.gov.hmrc.identityverificationquestions.models.payment.{Employment, Payment}
 import uk.gov.hmrc.identityverificationquestions.models.{Selection, ServiceName, p45Service}
-import uk.gov.hmrc.identityverificationquestions.models.payment.Payment
 import uk.gov.hmrc.identityverificationquestions.monitoring.metric.MetricsService
 import uk.gov.hmrc.identityverificationquestions.services.utilities.TaxYear
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
-class P45ConnectorSpec extends UnitSpec with LogCapturing {
+class P45ConnectorSpec extends UnitSpec with LogCapturing with MockHttpClientV2 {
 
   "calling getRecords" should {
     "return a sequence of Payment records" when {
       "valid identifiers provided" in new Setup {
+        val expectedData: Seq[Employment] = Seq(Employment(Seq(paymentTwo, paymentOne, paymentThree, paymentFour)))
+
         (mockAppConfig.hodConfiguration(_: ServiceName)).expects(*).returning(Right(HodConf("authToken", "envHeader")))
         (mockAppConfig.serviceBaseUrl(_: ServiceName)).expects(*).returning("http://localhost:8080")
+        mockHttpClientV2Get(url"http://localhost:8080/rti/individual/payments/nino/AA000000/tax-year/20-21")
+        mockHttpClientV2SetHeader()
+        mockHttpClientV2Execute[Seq[Employment]](expectedData)
 
         val expectedResponse: Seq[Payment] = Seq(paymentOne)
 
@@ -66,24 +69,10 @@ class P45ConnectorSpec extends UnitSpec with LogCapturing {
 
     def getResponse: Future[HttpResponse] = Future.successful(HttpResponse.apply(OK, p60ResponseJson, Map[String,Seq[String]]()))
 
-    val http: HttpGet =  new HttpGet {
-      override protected def actorSystem: ActorSystem = ActorSystem("for-get")
-
-      override protected def configuration: Config = app.injector.instanceOf[Config]
-
-      override val hooks: Seq[HttpHook] = Nil
-
-      override def doGet(url: String, headers: Seq[(String, String)] = Seq.empty)(implicit ec: ExecutionContext): Future[HttpResponse] = {
-        capturedUrl = url
-        capturedHc = hc
-        getResponse
-      }
-    }
-
     val mockAppConfig: AppConfig = mock[AppConfig]
     val metricsService: MetricsService = app.injector.instanceOf[MetricsService]
 
-    val connector: P45Connector = new P45Connector(http, metricsService, mockAppConfig) {
+    val connector: P45Connector = new P45Connector(mockHttpClientV2, metricsService, mockAppConfig) {
       override def serviceName: ServiceName = p45Service
       override protected def getTaxYears = Seq(TaxYear(2020))
     }

--- a/test/uk/gov/hmrc/identityverificationquestions/sources/empRef/EmpRefConnectorSpec.scala
+++ b/test/uk/gov/hmrc/identityverificationquestions/sources/empRef/EmpRefConnectorSpec.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.identityverificationquestions.sources.empRef
 
 import Utils.UnitSpec
-import uk.gov.hmrc.http.HttpGet
+import mocks.MockHttpClientV2
 import uk.gov.hmrc.identityverificationquestions.config.AppConfig
 import uk.gov.hmrc.identityverificationquestions.models._
 import uk.gov.hmrc.identityverificationquestions.monitoring.metric.MetricsService
 
 import java.time.LocalDate
 
-class EmpRefConnectorSpec extends UnitSpec {
+class EmpRefConnectorSpec extends UnitSpec with MockHttpClientV2 {
 
   "lastTwoYearsOfPayments" should {
     "return the last 2 years of payment details" in new Setup {
@@ -44,9 +44,8 @@ class EmpRefConnectorSpec extends UnitSpec {
   }
 
   trait Setup {
-    val mockHttpGet: HttpGet = mock[HttpGet]
     val metricsService: MetricsService = mock[MetricsService]
     val mockAppConfig: AppConfig = mock[AppConfig]
-    val empRefConnector = new EmpRefConnector(mockHttpGet, metricsService, mockAppConfig)
+    val empRefConnector = new EmpRefConnector(mockHttpClientV2, metricsService, mockAppConfig)
   }
 }


### PR DESCRIPTION
### General:
- Dependencies updated
- Bootstrap updated
- Test Script added
- DependencyUpdate plugin updated

### HTTPV2:
- HttpClientModule swapped for HttpClientV2Module
- Connectors swapped to use HttpClientV2

### Testing:
- Unit connector Tests updated to use HttpClientV2
- Unit connector tests use a MockHttpClientV2 helper trait
- Integration connector tests now use a stubbed WireMock response instead of calling services directly
- Various new tests added to cover error scenarios


